### PR TITLE
add jekyll friendly formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,15 @@ sudo cp target/release/typrint /usr/bin/typrint
 ![](images/usage.png)
 
 # Docker 🐳
+
 ## Run the latest version
+
 ```bash
 docker run --rm -it ghcr.io/skwalexe/typrint:main
 ```
+
 ## Test your changes 🚧
+
 ### Build 🛠️
 
 ```bash


### PR DESCRIPTION
jekyll doesn't render correctly when there are no line breaks between titles, code blocks etc